### PR TITLE
fix block extraction if asking question

### DIFF
--- a/tools/update-wechat-devtools
+++ b/tools/update-wechat-devtools
@@ -115,7 +115,7 @@ let client = @.net.httpClient();
 
     @.fs.makeDirs(extractPath);
 
-    @.task.execute("7z", ["x", localPath, `-o${extractPath}`, packageDir], extractPath, (error) => {
+    @.task.execute("7z", ["x", '-y', localPath, `-o${extractPath}`, packageDir], extractPath, (error) => {
 
         if (error) {
             this.reject(error); return;


### PR DESCRIPTION
.exe webdevtools块的提取有时会出现，因为它正在请求一些权限来覆盖某些文件。 使用选项“ -y”，脚本将自动应答。/
the extraction of the .exe webdevtools block sometime because it is asking some permission to overwrite some files. With the option "-y" the script will answer automatically.